### PR TITLE
Add Terraform IaC implementation

### DIFF
--- a/terraform/.gitignore
+++ b/terraform/.gitignore
@@ -1,0 +1,11 @@
+.terraform/
+.build/
+*.tfstate
+*.tfstate.backup
+terraform.tfvars
+*.tfvars
+crash.log
+override.tf
+override.tf.json
+*_override.tf
+*_override.tf.json

--- a/terraform/.terraform.lock.hcl
+++ b/terraform/.terraform.lock.hcl
@@ -1,0 +1,45 @@
+# This file is maintained automatically by "terraform init".
+# Manual edits may be lost in future updates.
+
+provider "registry.terraform.io/hashicorp/archive" {
+  version     = "2.7.1"
+  constraints = "~> 2.0"
+  hashes = [
+    "h1:Tr6LvLbm30zX4BRNPHhXo8SnOP0vg5UKAeunRNfnas8=",
+    "zh:19881bb356a4a656a865f48aee70c0b8a03c35951b7799b6113883f67f196e8e",
+    "zh:2fcfbf6318dd514863268b09bbe19bfc958339c636bcbcc3664b45f2b8bf5cc6",
+    "zh:3323ab9a504ce0a115c28e64d0739369fe85151291a2ce480d51ccbb0c381ac5",
+    "zh:362674746fb3da3ab9bd4e70c75a3cdd9801a6cf258991102e2c46669cf68e19",
+    "zh:7140a46d748fdd12212161445c46bbbf30a3f4586c6ac97dd497f0c2565fe949",
+    "zh:78d5eefdd9e494defcb3c68d282b8f96630502cac21d1ea161f53cfe9bb483b3",
+    "zh:875e6ce78b10f73b1efc849bfcc7af3a28c83a52f878f503bb22776f71d79521",
+    "zh:b872c6ed24e38428d817ebfb214da69ea7eefc2c38e5a774db2ccd58e54d3a22",
+    "zh:cd6a44f731c1633ae5d37662af86e7b01ae4c96eb8b04144255824c3f350392d",
+    "zh:e0600f5e8da12710b0c52d6df0ba147a5486427c1a2cc78f31eea37a47ee1b07",
+    "zh:f21b2e2563bbb1e44e73557bcd6cdbc1ceb369d471049c40eb56cb84b6317a60",
+    "zh:f752829eba1cc04a479cf7ae7271526b402e206d5bcf1fcce9f535de5ff9e4e6",
+  ]
+}
+
+provider "registry.terraform.io/hashicorp/aws" {
+  version     = "5.100.0"
+  constraints = "~> 5.0"
+  hashes = [
+    "h1:hd45qFU5cFuJMpFGdUniU9mVIr5LYVWP1uMeunBpYYs=",
+    "zh:054b8dd49f0549c9a7cc27d159e45327b7b65cf404da5e5a20da154b90b8a644",
+    "zh:0b97bf8d5e03d15d83cc40b0530a1f84b459354939ba6f135a0086c20ebbe6b2",
+    "zh:1589a2266af699cbd5d80737a0fe02e54ec9cf2ca54e7e00ac51c7359056f274",
+    "zh:6330766f1d85f01ae6ea90d1b214b8b74cc8c1badc4696b165b36ddd4cc15f7b",
+    "zh:7c8c2e30d8e55291b86fcb64bdf6c25489d538688545eb48fd74ad622e5d3862",
+    "zh:99b1003bd9bd32ee323544da897148f46a527f622dc3971af63ea3e251596342",
+    "zh:9b12af85486a96aedd8d7984b0ff811a4b42e3d88dad1a3fb4c0b580d04fa425",
+    "zh:9f8b909d3ec50ade83c8062290378b1ec553edef6a447c56dadc01a99f4eaa93",
+    "zh:aaef921ff9aabaf8b1869a86d692ebd24fbd4e12c21205034bb679b9caf883a2",
+    "zh:ac882313207aba00dd5a76dbd572a0ddc818bb9cbf5c9d61b28fe30efaec951e",
+    "zh:bb64e8aff37becab373a1a0cc1080990785304141af42ed6aa3dd4913b000421",
+    "zh:dfe495f6621df5540d9c92ad40b8067376350b005c637ea6efac5dc15028add4",
+    "zh:f0ddf0eaf052766cfe09dea8200a946519f653c384ab4336e2a4a64fdd6310e9",
+    "zh:f1b7e684f4c7ae1eed272b6de7d2049bb87a0275cb04dbb7cda6636f600699c9",
+    "zh:ff461571e3f233699bf690db319dfe46aec75e58726636a0d97dd9ac6e32fb70",
+  ]
+}

--- a/terraform/apigateway.tf
+++ b/terraform/apigateway.tf
@@ -1,0 +1,44 @@
+resource "aws_apigatewayv2_api" "http_api" {
+  name          = "HttpApi4328"
+  protocol_type = "HTTP"
+}
+
+resource "aws_apigatewayv2_authorizer" "lambda_authorizer" {
+  api_id                            = aws_apigatewayv2_api.http_api.id
+  name                              = "HttpApiGatewayAuthorizer"
+  authorizer_type                   = "REQUEST"
+  enable_simple_responses           = true
+  authorizer_uri                    = aws_lambda_function.authorization_lambda.invoke_arn
+  authorizer_result_ttl_in_seconds  = 0
+  authorizer_payload_format_version = "2.0"
+  authorizer_credentials_arn        = aws_iam_role.apigw_invoke_lambda_role.arn
+  identity_sources                  = ["$request.header.Authorization"]
+}
+
+resource "aws_apigatewayv2_stage" "dev" {
+  api_id      = aws_apigatewayv2_api.http_api.id
+  name        = "dev"
+  auto_deploy = true
+}
+
+resource "aws_apigatewayv2_integration" "main_lambda" {
+  api_id                 = aws_apigatewayv2_api.http_api.id
+  integration_type       = "AWS_PROXY"
+  payload_format_version = "2.0"
+  integration_uri        = aws_lambda_function.main_lambda.invoke_arn
+}
+
+resource "aws_apigatewayv2_route" "invoke" {
+  api_id             = aws_apigatewayv2_api.http_api.id
+  route_key          = "ANY /invoke"
+  authorization_type = "CUSTOM"
+  authorizer_id      = aws_apigatewayv2_authorizer.lambda_authorizer.id
+  target             = "integrations/${aws_apigatewayv2_integration.main_lambda.id}"
+}
+
+resource "aws_lambda_permission" "apigw_invoke_main_lambda" {
+  action        = "lambda:InvokeFunction"
+  function_name = aws_lambda_function.main_lambda.function_name
+  principal     = "apigateway.amazonaws.com"
+  source_arn    = "${aws_apigatewayv2_api.http_api.execution_arn}/*/*/invoke"
+}

--- a/terraform/iam.tf
+++ b/terraform/iam.tf
@@ -1,0 +1,178 @@
+###############################################################################
+# IAM Role: Authorization Lambda
+###############################################################################
+
+resource "aws_iam_role" "authorization_lambda_role" {
+  name = "AuthorizationLambdaExecutionRole"
+
+  assume_role_policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [
+      {
+        Effect = "Allow"
+        Principal = {
+          Service = "lambda.amazonaws.com"
+        }
+        Action = "sts:AssumeRole"
+      }
+    ]
+  })
+}
+
+resource "aws_iam_role_policy" "authorization_lambda_cloudwatch" {
+  name = "CloudWatchLogPolicy"
+  role = aws_iam_role.authorization_lambda_role.id
+
+  policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [
+      {
+        Effect = "Allow"
+        Action = [
+          "logs:CreateLogGroup",
+          "logs:CreateLogStream",
+          "logs:PutLogEvents"
+        ]
+        Resource = "*"
+      }
+    ]
+  })
+}
+
+resource "aws_iam_role_policy" "authorization_lambda_secrets" {
+  name = "SecretReadPolicy"
+  role = aws_iam_role.authorization_lambda_role.id
+
+  policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [
+      {
+        Effect   = "Allow"
+        Action   = ["secretsmanager:GetSecretValue"]
+        Resource = aws_secretsmanager_secret.auth_secret.arn
+      }
+    ]
+  })
+}
+
+resource "aws_iam_role_policy" "authorization_lambda_apigw" {
+  name = "ApiGatewayInvokePolicy"
+  role = aws_iam_role.authorization_lambda_role.id
+
+  policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [
+      {
+        Effect   = "Allow"
+        Action   = ["execute-api:Invoke"]
+        Resource = "${aws_apigatewayv2_api.http_api.execution_arn}/*/*/invoke"
+      }
+    ]
+  })
+}
+
+###############################################################################
+# IAM Role: Main Lambda
+###############################################################################
+
+resource "aws_iam_role" "main_lambda_role" {
+  name = "MainLambdaExecutionRole"
+
+  assume_role_policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [
+      {
+        Effect = "Allow"
+        Principal = {
+          Service = "lambda.amazonaws.com"
+        }
+        Action = "sts:AssumeRole"
+      }
+    ]
+  })
+}
+
+resource "aws_iam_role_policy_attachment" "main_lambda_basic_execution" {
+  role       = aws_iam_role.main_lambda_role.name
+  policy_arn = "arn:aws:iam::aws:policy/service-role/AWSLambdaBasicExecutionRole"
+}
+
+resource "aws_iam_role_policy" "main_lambda_bedrock" {
+  name = "BedrockAccessPolicy"
+  role = aws_iam_role.main_lambda_role.id
+
+  policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [
+      {
+        Effect = "Allow"
+        Action = [
+          "bedrock:InvokeModel",
+          "bedrock:ListFoundationModels"
+        ]
+        Resource = "*"
+      }
+    ]
+  })
+}
+
+resource "aws_iam_role_policy" "main_lambda_s3" {
+  name = "BucketPutPolicy"
+  role = aws_iam_role.main_lambda_role.id
+
+  policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [
+      {
+        Effect   = "Allow"
+        Action   = ["s3:PutObject"]
+        Resource = "${aws_s3_bucket.logs_bucket.arn}/*"
+      }
+    ]
+  })
+}
+
+###############################################################################
+# IAM Role: API Gateway invoke Lambda
+###############################################################################
+
+resource "aws_iam_role" "apigw_invoke_lambda_role" {
+  name = "ApiGatewayInvokeLambdaRole"
+
+  assume_role_policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [
+      {
+        Effect = "Allow"
+        Principal = {
+          Service = "apigateway.amazonaws.com"
+        }
+        Action = "sts:AssumeRole"
+      }
+    ]
+  })
+}
+
+resource "aws_iam_role_policy" "apigw_invoke_policy" {
+  name = "AuthorizerPermissionsPolicy"
+  role = aws_iam_role.apigw_invoke_lambda_role.id
+
+  policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [
+      {
+        Effect = "Allow"
+        Action = [
+          "lambda:InvokeFunction",
+          "sts:AssumeRole"
+        ]
+        Resource = aws_lambda_function.authorization_lambda.arn
+      },
+      {
+        Effect   = "Allow"
+        Action   = ["execute-api:Invoke"]
+        Resource = "${aws_apigatewayv2_api.http_api.execution_arn}/*/*/invoke"
+      }
+    ]
+  })
+}

--- a/terraform/lambda.tf
+++ b/terraform/lambda.tf
@@ -1,0 +1,48 @@
+data "archive_file" "authorizer_lambda_zip" {
+  type        = "zip"
+  source_file = "${path.module}/lambda_src/authorizer/index.py"
+  output_path = "${path.module}/.build/authorizer.zip"
+}
+
+data "archive_file" "main_lambda_zip" {
+  type        = "zip"
+  source_file = "${path.module}/lambda_src/main/index.py"
+  output_path = "${path.module}/.build/main.zip"
+}
+
+resource "aws_lambda_function" "authorization_lambda" {
+  function_name    = "AuthorizationLambdaFunction"
+  description      = "Lambda Authorizer for API Gateway"
+  role             = aws_iam_role.authorization_lambda_role.arn
+  handler          = "index.lambda_handler"
+  runtime          = "python3.12"
+  timeout          = 10
+  memory_size      = 128
+  filename         = data.archive_file.authorizer_lambda_zip.output_path
+  source_code_hash = data.archive_file.authorizer_lambda_zip.output_base64sha256
+
+  environment {
+    variables = {
+      AuthSecret = var.auth_secret_name
+    }
+  }
+}
+
+resource "aws_lambda_function" "main_lambda" {
+  function_name    = "MainLambdaFunction"
+  description      = "Make requests to Bedrock models"
+  role             = aws_iam_role.main_lambda_role.arn
+  handler          = "index.lambda_handler"
+  runtime          = "python3.12"
+  timeout          = 30
+  memory_size      = 512
+  filename         = data.archive_file.main_lambda_zip.output_path
+  source_code_hash = data.archive_file.main_lambda_zip.output_base64sha256
+
+  environment {
+    variables = {
+      BEDROCK_MODEL_ID = var.bedrock_model_id
+      BUCKET_NAME      = var.bucket_name
+    }
+  }
+}

--- a/terraform/lambda_src/authorizer/index.py
+++ b/terraform/lambda_src/authorizer/index.py
@@ -1,0 +1,52 @@
+import boto3
+from botocore.exceptions import ClientError
+import json
+import os
+
+
+def lambda_handler(event, context):
+    secret_name = os.environ['AuthSecret']
+    region_name = context.invoked_function_arn.split(":")[3]
+
+    session = boto3.session.Session()
+    client = session.client(
+        service_name='secretsmanager',
+        region_name=region_name
+    )
+    try:
+        get_secret_value_response = client.get_secret_value(
+            SecretId=secret_name
+        )
+        secret_token = get_secret_value_response['SecretString']
+
+        # Access the authorization token from identitySource
+        authorization_header = event.get('identitySource', [None])[0]
+
+        # Check if the authorization header is properly set
+        if not authorization_header:
+            return {"isAuthorized": False}
+
+        # Extract the token from the Bearer scheme
+        token_parts = authorization_header.split(' ')
+        if len(token_parts) != 2 or token_parts[0].lower() != 'bearer':
+            return {"isAuthorized": False}
+
+        token = token_parts[1]
+
+        # Check if the provided token matches the secret token
+        is_authorized = token == secret_token
+
+        print("Request authenticated successfully")
+        # Construct the response
+        response = {
+            "isAuthorized": is_authorized
+        }
+        return response
+    except ClientError as e:
+        print(f"Error retrieving parameter: {e}")
+        return {
+            "isAuthorized": False,
+            "context": {
+                "error": "Internal server error"
+            }
+        }

--- a/terraform/lambda_src/main/index.py
+++ b/terraform/lambda_src/main/index.py
@@ -1,0 +1,104 @@
+import json
+import boto3
+import os
+import logging
+import time
+from botocore.exceptions import ClientError
+
+# Initialize logging
+logger = logging.getLogger()
+logger.setLevel(logging.INFO)
+
+# Initialize the Bedrock Runtime client
+bedrock_runtime = boto3.client('bedrock-runtime')
+
+
+def lambda_handler(event, context):
+    logger.info('Received event: %s', json.dumps(event))
+
+    try:
+        # Retrieve the model ID from environment variables
+        model_id = os.environ['BEDROCK_MODEL_ID']
+        print("In lambda handle !!")
+        # Validate the input
+        input_text = event.get("queryStringParameters", {}).get("inputText")
+        input_task = event.get("queryStringParameters", {}).get("inputTask")
+        if not input_text or not input_task:
+            logger.error('Input text / Input task is missing in the request')
+            raise ValueError("Input text / Input task is required in the request query parameters.")
+
+        combined_prompt = f"Task: {input_task}\n\nContent to analyze: {input_text}"
+
+        payload = [
+            {
+                "role": "user",
+                "content": [{"text": combined_prompt}]
+            }
+        ]
+
+        logger.info('Payload for Bedrock model: %s', payload)
+
+        response = bedrock_runtime.converse(
+            modelId=model_id,
+            messages=payload,
+            inferenceConfig={
+                "maxTokens": 600,
+                "temperature": 0.3,
+                "topP": 0.9
+            },
+        )
+
+        logger.info('Response from Bedrock model: %s', response)
+
+        # Check if the 'output' exists in the response and handle it correctly
+        if 'output' not in response or not response['output']:
+            logger.error('Response output is empty')
+            raise ValueError("Response output is empty.")
+
+        # Read and process the response
+        response_body = response['output']
+        print(type(response_body))
+        logger.info('Processed response body: %s', response_body)
+        response_message = response['output']['message']
+        response_text = response_message['content'][0]['text']
+
+        fileName = "request-" + str(int(time.time())) + ".txt"
+        log_content = {
+            "request_payload": payload,
+            "response_output": response_text,
+            "model_used": model_id
+        }
+
+        # Upload the file
+        s3_client = boto3.client('s3')
+        bucket_name = os.environ['BUCKET_NAME']
+        try:
+            resp = s3_client.put_object(Bucket=bucket_name, Key=fileName, Body=json.dumps(log_content).encode("utf-8"))
+        except ClientError as e:
+            logging.error(e)
+
+        rawResponse = json.dumps({"analysis": response_text.strip()})
+        rawResponse = rawResponse.replace('\n\n', '')
+        return {
+            'statusCode': 200,
+            'body': rawResponse
+        }
+
+    except ClientError as e:
+        logger.error('ClientError: %s', e)
+        return {
+            'statusCode': 500,
+            'body': json.dumps({"error": "Error interacting with the Bedrock API"})
+        }
+    except ValueError as e:
+        logger.error('ValueError: %s', e)
+        return {
+            'statusCode': 400,
+            'body': json.dumps({"error": str(e)})
+        }
+    except Exception as e:
+        logger.error('Exception: %s', e)
+        return {
+            'statusCode': 500,
+            'body': json.dumps({"error": "Internal Server Error"})
+        }

--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -1,0 +1,18 @@
+terraform {
+  required_version = ">= 1.0"
+
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = "~> 5.0"
+    }
+    archive = {
+      source  = "hashicorp/archive"
+      version = "~> 2.0"
+    }
+  }
+}
+
+provider "aws" {
+  region = var.aws_region
+}

--- a/terraform/outputs.tf
+++ b/terraform/outputs.tf
@@ -1,0 +1,9 @@
+output "api_invoke_url" {
+  description = "Full URL to invoke the API"
+  value       = "${aws_apigatewayv2_stage.dev.invoke_url}/invoke"
+}
+
+output "api_endpoint" {
+  description = "API Gateway endpoint"
+  value       = aws_apigatewayv2_api.http_api.api_endpoint
+}

--- a/terraform/s3.tf
+++ b/terraform/s3.tf
@@ -1,0 +1,3 @@
+resource "aws_s3_bucket" "logs_bucket" {
+  bucket = var.bucket_name
+}

--- a/terraform/secrets.tf
+++ b/terraform/secrets.tf
@@ -1,0 +1,8 @@
+resource "aws_secretsmanager_secret" "auth_secret" {
+  name = var.auth_secret_name
+}
+
+resource "aws_secretsmanager_secret_version" "auth_secret_value" {
+  secret_id     = aws_secretsmanager_secret.auth_secret.id
+  secret_string = var.auth_secret_value
+}

--- a/terraform/variables.tf
+++ b/terraform/variables.tf
@@ -1,0 +1,29 @@
+variable "aws_region" {
+  description = "AWS region to deploy resources"
+  type        = string
+  default     = "us-east-1"
+}
+
+variable "auth_secret_name" {
+  description = "Name of the Secrets Manager secret for API Gateway authorization"
+  type        = string
+  default     = "AuthSecret"
+}
+
+variable "auth_secret_value" {
+  description = "Value of the authorization secret"
+  type        = string
+  sensitive   = true
+}
+
+variable "bedrock_model_id" {
+  description = "Bedrock model ID to use for inference"
+  type        = string
+  default     = "us.amazon.nova-micro-v1:0"
+}
+
+variable "bucket_name" {
+  description = "S3 bucket name for storing request/response logs"
+  type        = string
+  default     = "logs-bucket-test-1"
+}


### PR DESCRIPTION
## Summary

Converts the imperative `driver.py` AWS deployment into a declarative Terraform configuration.

## Resources managed

- **Secrets Manager** secret (`AuthSecret`) + secret version
- **S3 bucket** for request/response logs
- **Lambda: AuthorizationLambdaFunction** — API Gateway authorizer (Python 3.12)
- **Lambda: MainLambdaFunction** — Bedrock inference handler (Python 3.12)
- **HTTP API Gateway** with Lambda authorizer, `ANY /invoke` route, and `dev` stage
- **3 IAM roles** with scoped policies
- **Lambda permission** for API Gateway invocation

## Improvements over driver.py

- S3 bucket and secret are now managed in the stack (no imperative pre-creation)
- S3 PutObject IAM policy scoped to the specific bucket ARN instead of `Resource: '*'`
- API invoke URL exposed as a Terraform output
- Secret value marked `sensitive` to prevent leaking in logs
- `.gitignore` excludes state files, `.terraform/`, and `.tfvars`

## Usage

```bash
cd terraform
terraform init
terraform apply -var="auth_secret_value=$(openssl rand -hex 32)"
```
